### PR TITLE
Fix pdns service plist

### DIFF
--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -57,9 +57,8 @@ class Pdns < Formula
       <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
-        <string>#{opt_bin}/pdns_server</string>
+        <string>#{sbin}/pdns_server</string>
       </array>
-      <key>EnvironmentVariables</key>
       <key>KeepAlive</key>
       <true/>
       <key>SHAuthorizationRight</key>


### PR DESCRIPTION
Fix path to `pdns_server` and remove key without value

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
